### PR TITLE
Fix broken links & dev error

### DIFF
--- a/docs/edit-scenario/modifications.mdx
+++ b/docs/edit-scenario/modifications.mdx
@@ -120,7 +120,7 @@ First, create a new modification and select _Convert to frequency_. Give the mod
   alt='A convert to frequency modification with a replacement timetable open'
 />
 
-Start by selecting a [GTFS feed](/glossary#GTFS--GTFS-feed) and then the route from that feed that you want to adjust. You should see all trip patterns for the selected route displayed on the map.
+Start by selecting a [GTFS feed](/glossary#gtfs--gtfs-feed) and then the route from that feed that you want to adjust. You should see all trip patterns for the selected route displayed on the map.
 
 You can choose to remove all existing trips on the route (the default) and start from scratch with new timetables. Or you may choose to retain trips outside the time windows in which you specify frequencies which is useful when you are changing the frequency for only part of the day (e.g. increased weekend frequency) and want to retain the existing scheduled service at other times. This is controlled using the checkbox labeled "_Retain existing scheduled trips at times without new frequencies specified_".
 
@@ -165,7 +165,7 @@ Another common modification is to remove trips. The most common use is to remove
 
 ### Reroute
 
-This modification type can be used to represent detours, extensions,and curtailments. When creating a _reroute_ modification, you first select a [GTFS feed](/glossary#GTFS--GTFS-feed), route, and [trip patterns](/glossary#trip-pattern). Once trip patterns are selected, you then select a stop at which the reroute alignment will start, or a stop at which the reroute alignment will end, or both, by clicking <Button variantColor='blue'><FaCrosshairs /> Select</Button> then clicking an existing stop on the baseline pattern.
+This modification type can be used to represent detours, extensions,and curtailments. When creating a _reroute_ modification, you first select a [GTFS feed](/glossary#gtfs--gtfs-feed), route, and [trip patterns](/glossary#trip-pattern). Once trip patterns are selected, you then select a stop at which the reroute alignment will start, or a stop at which the reroute alignment will end, or both, by clicking <Button variantColor='blue'><FaCrosshairs /> Select</Button> then clicking an existing stop on the baseline pattern.
 
 Note that every selected pattern must stop at the selected start-of-reroute stop and end-of-reroute stop. For example, consider these three patterns:
 1. A-B-C-D-E

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -20,7 +20,7 @@ A modification is an alteration of some kind made to scheduled transit services.
 A network bundle consists of an OpenStreetMap file and one or more [General Transit Feed Specification](#gtfs--gtfs-feed) (GTFS) feeds associated with your region. A region can have multiple bundles, and a bundle can include a single agency's GTFS or feeds from several adjacent or overlapping agencies.
 
 ## Spatial dataset
-A spatial dataset has one or more layers representing origin points or numeric counts of destination opportunities at particular locations in your [region](#region). See [uploading opportunities](/prepare-inputs/upload-spatial-data#upload_opportunities).
+A spatial dataset has one or more layers representing origin points or numeric counts of destination opportunities at particular locations in your [region](#region). See [uploading opportunities](/prepare-inputs/upload-spatial-data#uploading-opportunities).
 
 ## Project
 A project is means of associating scenarios and modifications with a particular network bundle. A project is associated with only one bundle, which cannot be changed after the project is created.

--- a/docs/learn-more/faq.mdx
+++ b/docs/learn-more/faq.mdx
@@ -4,7 +4,7 @@ title: Frequently asked questions
 
 ### How does Conveyal Analysis calculate travel times?
 
-Conveyal Analysis calculates door-to-door total travel time. Travel times are always computed by finding actual paths through a full street and (where applicable) public transport ("transit", in American English) network. By default, Conveyal Analysis uses the centers of [high-resolution grid cells](/analysis/methodology#spatial-grid) as destinations.
+Conveyal Analysis calculates door-to-door total travel time. Travel times are always computed by finding actual paths through a full street and (where applicable) public transport ("transit", in American English) network. By default, Conveyal Analysis uses the centers of [high-resolution grid cells](/analysis/methodology#spatial-resolution) as destinations.
 
 For analyses with transit disabled, the total travel time from an origin to a destination includes time spent:
 

--- a/docs/prepare-inputs/index.mdx
+++ b/docs/prepare-inputs/index.mdx
@@ -112,7 +112,7 @@ osmium tags-filter input.osm.pbf \
 
 ## Uploading GTFS feeds
 
-If your new network bundle will not be re-using previously uploaded GTFS, start by gathering [GTFS feeds](/glossary#GTFS--GTFS-feed) for the transit agencies whose service you want to include. A GTFS feed is a set of CSV files inside a `.zip` archive.
+If your new network bundle will not be re-using previously uploaded GTFS, start by gathering [gtfs feeds](/glossary#gtfs--gtfs-feed) for the transit agencies whose service you want to include. A GTFS feed is a set of CSV files inside a `.zip` archive.
 
 Once these files are gathered on your computer, select the .zip files to upload in the "Upload new GTFS" tab of the network bundle creation panel. You can select multiple GTFS feeds in the file dialogue by shift-clicking, control-clicking or command-clicking (depending on your browser/operating system).
 

--- a/static/js/external/script.js
+++ b/static/js/external/script.js
@@ -1,0 +1,1 @@
+// dev placeholder


### PR DESCRIPTION
- Fix "broken links". Docusaurus marked these links as broken (they still went to the page, but the hash didn't navigate to the correct heading).
- In local dev mode, each page keeps trying to load `/js/external/script.js` causing an error. I added a placeholder to prevent that error. This script is rewritten to Plausible on production.